### PR TITLE
fix(hasClass): querySelector may be return null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,9 @@ export default {
   // el can be an Element or selector
   hasClass(el, className) {
     if (typeof el === 'string') el = document.querySelector(el);
+    if (!el) {
+      return false;
+    }
     if (el.classList) {
       return el.classList.contains(className);
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -93,6 +93,11 @@ describe('oui-dom-utils', () => {
       expect(D.hasClass('.item', 'item-i')).to.be.true;
       expect(D.hasClass('.item', 'item-ii')).to.be.false;
     });
+
+    it('document.querySelector return null', () => {
+      expect(D.hasClass('.test', 'item-i')).to.be.false;
+      expect(D.hasClass('.test', 'item-ii')).to.be.false;
+    });
   });
 
   describe('#toggleClass', () => {


### PR DESCRIPTION
hasClass will throw error, if document.querySelector return null